### PR TITLE
give renv-setup a type variable to allow for different setups

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,13 +33,14 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
-      - name: Install libcurl on Linux
+      - name: Install system dependencies on Linux
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update -y
           sudo apt-get install -y libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev
       - uses: ./setup-renv
         with:
+          type: 'restore'
           lockfile: 'setup-pkgdown/renv.lock'
       - name: Build site
         shell: Rscript {0}

--- a/.github/workflows/renv-r-pkg.yaml
+++ b/.github/workflows/renv-r-pkg.yaml
@@ -1,4 +1,4 @@
-name: renv-restore-template
+name: renv-r-pkg-template
 on:
   push:
     branches: [main]

--- a/.github/workflows/renv-r-pkg.yaml
+++ b/.github/workflows/renv-r-pkg.yaml
@@ -1,11 +1,4 @@
-# Workflow derived from:
-# https://github.com/r-lib/actions/blob/v2-branch/examples/pkgdown.yaml
-# https://github.com/r-lib/actions/tree/v2/setup-renv
-# https://github.com/actions/cache/blob/main/examples.md#r---renv
-# https://github.com/jdjohn215/milwaukee-weather/tree/main/.github/workflows
-# https://github.com/r-lib/actions/blob/v2-branch/examples/check-standard.yaml
-
-name: renv-template
+name: renv-restore-template
 on:
   push:
     branches: [main]
@@ -45,4 +38,5 @@ jobs:
           use-public-rspm: true
       - uses: ./setup-renv
         with:
-          lockfile: 'setup-renv/renv.lock'
+          type: 'r-pkg'
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/renv-restore.yaml
+++ b/.github/workflows/renv-restore.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from:
+# https://github.com/r-lib/actions/blob/v2-branch/examples/pkgdown.yaml
+# https://github.com/r-lib/actions/tree/v2/setup-renv
+# https://github.com/actions/cache/blob/main/examples.md#r---renv
+# https://github.com/jdjohn215/milwaukee-weather/tree/main/.github/workflows
+# https://github.com/r-lib/actions/blob/v2-branch/examples/check-standard.yaml
+
+name: renv-restore-template
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  setup-renv:
+    name: ${{ matrix.os }} (${{ matrix.r }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        r: ['release']
+        r-repo: ['https://packagemanager.rstudio.com/all/__linux__/focal/latest']
+    # Runs all jobs concurrently - also will cancel in progress jobs on new trigger events
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.run_id }}
+      cancel-in-progress: true
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      RENV_CONFIG_REPOS_OVERRIDE: ${{ matrix.r-repo }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          # change to false to forgo R install & use pre-installed R version in specified runner
+          install-r: true
+          r-version: ${{ matrix.r }}
+          http-user-agent: ${{ matrix.http-user-agent }}
+          # use RStudio's CRAN mirror with precompiled binaries
+          use-public-rspm: true
+      - uses: ./setup-renv
+        with:
+          type: 'restore'
+          lockfile: 'setup-renv/renv.lock'

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # templates test out the actions & are great files to add to your repo
 .PHONY: all setup_gha setup_site setup_pkgdown setup_rmd build_index build_pkgdown build_rmd build_r_pkg r_pkg_check preview
 
-GHA_DIRS = setup-renv setup-pkgdown setup-index
-GHA_WORKFLOWS_FILES = renv.yaml pkgdown.yaml index.yaml
+GHA_DIRS = setup-renv setup-pkgdown setup-index check-r-package
+GHA_WORKFLOWS_FILES = renv.yaml pkgdown.yaml index.yaml check-release.yaml
 # GitHub Actions
 GHAS = $(addsuffix /action.yaml,$(GHA_DIRS))
 # Template Workflows

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -35,8 +35,11 @@ runs:
       - name: Set LOCKFILE
         shell: bash
         run: |
-          if [[ ${{ inputs.type }} == 'r-pkg' ]]; then LOCKFILE=renv.lock; else LOCKFILE=${{ inputs.lockfile }}; fi
-          echo 'LOCKFILE=${LOCKFILE}' >> $GITHUB_ENV
+          if [[ ${{ inputs.type }} == 'r-pkg' ]]; then
+            echo 'LOCKFILE=renv.lock' >> $GITHUB_ENV
+          else
+            echo 'LOCKFILE=${{ inputs.lockfile }}' >> $GITHUB_ENV
+          fi 
       - name: Get R and OS version
         id: get-version
         shell: Rscript {0}

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -20,6 +20,7 @@ runs:
   using: 'composite'
   steps:
       - name: Set RENV_PATHS_ROOT
+        shell: bash
         run: echo 'RENV_PATHS_ROOT=${{ runner.temp }}/renv' >> $GITHUB_ENV
       - name: Install and activate renv
         shell: Rscript {0}
@@ -32,6 +33,7 @@ runs:
           renv::install('rcmdcheck')
           renv::snapshot()
       - name: Set LOCKFILE
+        shell: bash
         run: |
           if [[ ${{ inputs.type }} == 'r-pkg' ]]; then LOCKFILE=renv.lock; else LOCKFILE=${{ inputs.lockfile }}; fi
           echo $LOCKFILE >> $GITHUB_ENV

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -1,25 +1,40 @@
 name: 'setup-renv'
-description: 'Action to restore & cache R packages from renv.lock'
+description: 'Action to use {renv} for package installation & actions/cache GHA to cache all installed packages.'
 inputs:
+  type:
+    description: > 
+      The type of {renv} package install & setup. Choose 1 of: ['r-pkg', 'restore']
+      r-pkg: installs packages based on DESCRIPTION file for `R CMD check` to be
+        ran on your R package via {rcmdcheck} & r-lib/actions/check-r-package GHA 
+      restore: restores package cache from specified renv.lock file set in `inputs.lockfile`
+    required: true
   cache-version:
     description: 'The version of the cache. Change this to bust cache & trigger storing a new cache.'
     required: true
     default: 1
   lockfile: 
-    description: 'Relative path to the renv.lock file.'
+    description: "Relative path to the renv.lock file. Only necessary for when `inputs.type` is set to 'restore'"
     required: true
     default: 'renv.lock'
 runs:
   using: 'composite'
   steps:
       - name: Set RENV_PATHS_ROOT
-        shell: bash
-        run: |
-          echo 'RENV_PATHS_ROOT=${{ runner.temp }}/renv' >> $GITHUB_ENV
+        run: echo 'RENV_PATHS_ROOT=${{ runner.temp }}/renv' >> $GITHUB_ENV
       - name: Install and activate renv
         shell: Rscript {0}
+        run: paste("activated via ./renv & ./.Rprofile")
+      - name: Install packages from DESCRIPTION & write new lockfile 
+        if: inputs.type == 'r-pkg'
+        shell: Rscript {0}
         run: |
-          paste("activated via ./renv & ./.Rprofile")
+          renv::install()
+          renv::install('rcmdcheck')
+          renv::snapshot()
+      - name: Set LOCKFILE
+        run: |
+          if [[ ${{ inputs.type }} == 'r-pkg' ]]; then LOCKFILE=renv.lock; else LOCKFILE=${{ inputs.lockfile }}; fi
+          echo $LOCKFILE >> $GITHUB_ENV
       - name: Get R and OS version
         id: get-version
         shell: Rscript {0}
@@ -30,8 +45,9 @@ runs:
         uses: actions/cache@v3
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-${{ hashFiles(inputs.lockfile) }}
+          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-${{ hashFiles(env.LOCKFILE) }}
           restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-
       - name: Restore packages from renv.lock file
+        if: inputs.type == 'restore'
         shell: Rscript {0}
         run: renv::restore(lockfile = "${{ inputs.lockfile }}")

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -36,7 +36,7 @@ runs:
         shell: bash
         run: |
           if [[ ${{ inputs.type }} == 'r-pkg' ]]; then LOCKFILE=renv.lock; else LOCKFILE=${{ inputs.lockfile }}; fi
-          echo $LOCKFILE >> $GITHUB_ENV
+          echo 'LOCKFILE="$LOCKFILE"' >> $GITHUB_ENV
       - name: Get R and OS version
         id: get-version
         shell: Rscript {0}

--- a/setup-renv/action.yaml
+++ b/setup-renv/action.yaml
@@ -36,7 +36,7 @@ runs:
         shell: bash
         run: |
           if [[ ${{ inputs.type }} == 'r-pkg' ]]; then LOCKFILE=renv.lock; else LOCKFILE=${{ inputs.lockfile }}; fi
-          echo 'LOCKFILE="$LOCKFILE"' >> $GITHUB_ENV
+          echo 'LOCKFILE=${LOCKFILE}' >> $GITHUB_ENV
       - name: Get R and OS version
         id: get-version
         shell: Rscript {0}
@@ -47,8 +47,8 @@ runs:
         uses: actions/cache@v3
         with:
           path: ${{ env.RENV_PATHS_ROOT }}
-          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-${{ hashFiles(env.LOCKFILE) }}
-          restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-
+          key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ github.workflow }}-${{ inputs.cache-version }}-${{ hashFiles(env.LOCKFILE) }}
+          restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ github.workflow }}-${{ inputs.cache-version }}-
       - name: Restore packages from renv.lock file
         if: inputs.type == 'restore'
         shell: Rscript {0}


### PR DESCRIPTION
Allows for different types of {renv} setups:

| inputs.type | description |
| ---- | ---- |
| 'r-pkg' | installs your R package's dependencies - sets up for R CMD check |
| 'restore' | restores from specified `inputs.lockfile` your project's R packages |